### PR TITLE
feat: add platform-specific window sizes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,8 +22,8 @@ void main() async {
   await windowManager.ensureInitialized();
   WindowOptions windowOptions = WindowOptions(
     title: APPConfig.appName,
-    size: Size(800, 600),
-    minimumSize: Size(800, 600),
+    size: Styles.size,
+    minimumSize: Styles.size,
     backgroundColor: Colors.white,
     skipTaskbar: false,
   );

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 class Styles {
@@ -9,6 +11,16 @@ class Styles {
   static double toolbarMinSize = 110;
 
   static Color textButtonColor = Colors.blue;
+
+  static final Size _macOSSize = Size(800, 600);
+  static final Size _windowsSize = Size(1280, 720);
+  static final Size _linuxSize = Size(1280, 720);
+
+  static Size get size => Platform.isMacOS
+      ? _macOSSize
+      : Platform.isWindows
+          ? _windowsSize
+          : _linuxSize;
 
   static ThemeData lightTheme = ThemeData(
     brightness: Brightness.light,


### PR DESCRIPTION
Define platform-specific window sizes for macOS, Windows, and Linux.  Update the main window options to use these sizes dynamically based on  the current platform. This improves the user experience by ensuring  the application window is appropriately sized for each operating system.